### PR TITLE
Fix wrong padding for Bye packet

### DIFF
--- a/lib/ex_rtcp/packet/goodbye.ex
+++ b/lib/ex_rtcp/packet/goodbye.ex
@@ -40,7 +40,7 @@ defmodule ExRTCP.Packet.Goodbye do
     len = byte_size(reason)
 
     pad_len =
-      case rem(len, 4) do
+      case rem(len + 1, 4) do
         0 -> 0
         other -> 4 - other
       end

--- a/test/ex_rtcp/packet/goodbye_test.exs
+++ b/test/ex_rtcp/packet/goodbye_test.exs
@@ -23,7 +23,7 @@ defmodule ExRTCP.Packet.GoodbyeTest do
 
     test "packet with reason" do
       sources = [@ssrc, @ssrc + 1, @ssrc + 2]
-      reason = "1234"
+      reason = "123"
 
       packet = %Goodbye{
         sources: sources,
@@ -31,6 +31,7 @@ defmodule ExRTCP.Packet.GoodbyeTest do
       }
 
       assert {encoded, 3, 203} = Goodbye.encode(packet)
+      assert rem(byte_size(encoded), 4) == 0
 
       bin = for i <- sources, do: <<i::32>>, into: <<>>
       bin = <<bin::binary, byte_size(reason)::8, reason::binary>>
@@ -40,7 +41,7 @@ defmodule ExRTCP.Packet.GoodbyeTest do
 
     test "packet with reason that's not multiple of 32 bits" do
       sources = [@ssrc, @ssrc + 1, @ssrc + 2]
-      reason = "123456"
+      reason = "1234"
 
       packet = %Goodbye{
         sources: sources,
@@ -48,9 +49,10 @@ defmodule ExRTCP.Packet.GoodbyeTest do
       }
 
       assert {encoded, 3, 203} = Goodbye.encode(packet)
+      assert rem(byte_size(encoded), 4) == 0
 
       bin = for i <- sources, do: <<i::32>>, into: <<>>
-      bin = <<bin::binary, byte_size(reason)::8, reason::binary, 0, 0>>
+      bin = <<bin::binary, byte_size(reason)::8, reason::binary, 0, 0, 0>>
 
       assert encoded == bin
     end

--- a/test/ex_rtcp/packet_test.exs
+++ b/test/ex_rtcp/packet_test.exs
@@ -68,4 +68,17 @@ defmodule ExRTCP.PacketTest do
       assert {:error, :unknown_type} = Packet.decode(bin)
     end
   end
+
+  describe "encode/decode" do
+    test "Encode decode" do
+      original_packet = %Goodbye{
+        sources: [12345, 67890],
+        reason: "Session ended"
+      }
+
+      encoded = Packet.encode(original_packet)
+      assert {:ok, decoded_packet} = Packet.decode(encoded)
+      assert original_packet == decoded_packet
+    end
+  end
 end


### PR DESCRIPTION
When padding is calculated for bye packet, the length field of reason is not taken into consideration.

A simple encode/decode like this fails
```elixir
original_packet = %ExRTCP.Packet.Goodbye{sources: [12345, 67890], reason: "Session ended"}
encoded = ExRTCP.Packet.encode(original_packet)
ExRTCP.Packet.decode(encoded) # returns {:error, :invalid_packet}
```
